### PR TITLE
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Apache CloudStack EC2stack
 
 **An EC2 Compatibility Interface For Apache CloudStack**
 
-[![Build Status](https://travis-ci.org/apache/cloudstack-ec2stack.svg?branch=master)](https://travis-ci.org/apache/cloudstack-ec2stack)
+[![Build Status](https://travis-ci.org/apache/cloudstack-ec2stack.svg?branch=main)](https://travis-ci.org/apache/cloudstack-ec2stack)
 
 Description
 -----------

--- a/performrelease.sh
+++ b/performrelease.sh
@@ -19,7 +19,7 @@
 version='TESTBUILD'
 sourcedir=~/cloudstack-ec2stack
 outputdir=/tmp/cloudstack-ec2stack-build/
-branch='master'
+branch='main'
 tag='no'
 certid='X'
 committosvn='X'
@@ -27,7 +27,7 @@ committosvn='X'
 usage(){
     echo "usage: $0 -v version [-b branch] [-s source dir] [-o output dir] [-t] [-u] [-c] [-h]"
     echo "  -v sets the version"
-    echo "  -b sets the branch (defaults to 'master')"
+    echo "  -b sets the branch (defaults to 'main')"
     echo "  -s sets the source directory (defaults to $sourcedir)"
     echo "  -o sets the output directory (defaults to $outputdir)"
     echo "  -t tags the git repo with the version"

--- a/pylint.rc
+++ b/pylint.rc
@@ -10,7 +10,7 @@
 # Profiled execution.
 profile=no
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=CVS
 


### PR DESCRIPTION
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

- Renamed default git branch name from 'master' to 'main'.

- Replaced whitelist and blacklist with allowlist and denylist respectively.